### PR TITLE
tidy up the template questions

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -136,7 +136,7 @@ services_repo:
 
 services_release:
   type: str
-  help: The initial release of the services repository to track e.g. "2024.12.1" or "main"
+  help: The initial tag or branch of the services repository to track e.g. "2024.12.1" or "main"
 
 logging_url:
   type: str

--- a/copier.yml
+++ b/copier.yml
@@ -1,7 +1,5 @@
 _message_before_copy: |
-  This template will create a new repository which describes the deployment IOCs and
-  services to a Kubernetes cluster using Argocd. Each repository gathers a collection
-  of ec services as Argocd Apps which are deployed to *the same Argocd Project*.
+  This template will create a new repository which describes the set of IOCs and services that Argo CD will track on a Kubernetes cluster.
 
 _subdirectory: "template"
 
@@ -9,8 +7,14 @@ _preserve_symlinks: true
 
 ioc_group:
   type: str
-  help: Short name for the collection of services.
-  placeholder: e.g. "t01", "VA", "PS"
+  help: |
+    A name for the group of IOC and service instances that this
+       repository will track.
+
+       At DLS this should be the short beamline name or the technical area
+       for accelerator repos.
+
+  placeholder: e.g. "i16", "b01-1", "p47" "vacuum"
   validator: >-
     {% if not (ioc_group | regex_search('^[a-zA-Z][a-zA-Z-0-9]+$')) %}
     {{ioc_group}} must be alphanumeric plus hyphens and start with a letter.
@@ -20,14 +24,23 @@ description:
   type: str
   help: A One line description of the module
   default: >-
-    {{ ioc_group }} IOC Instances and Services
+    {{ ioc_group }} IOC Instances and Services Deployment Repository for Argo CD
 
 argocd_server:
   type: str
-  help: Argocd server URI. For missing platform override argocd_server, or add your own in a PR.
-  choices:
-    argocd.diamond.ac.uk: argocd.diamond.ac.uk
-    specify: ""
+  help: |
+    Argocd server DNS Name.
+
+       At DLS this is always "argocd.diamond.ac.uk"
+  default: argocd.diamond.ac.uk
+
+argocd_cluster:
+  type: str
+  help: |
+    Cluster in which Argo CD Apps are deployed.
+
+       At DLS this is always "argus"
+  default: argus
 
 argocd_server_custom:
   type: str
@@ -35,66 +48,40 @@ argocd_server_custom:
   when: >-
     {{ not argocd_server }}
 
-argocd_project:
+cluster_name:
   type: str
-  help: Argocd project e.g. "bl01t", "VA", "PS"
-  default:  >-
+  help: |
+    The Kubernetes cluster where the IOCs and services will run.
+
+       At DLS this should be "{beamline shortname}", "acastus" for the
+       accelerator or "pollux" for test beamlines.
+  placeholder: e.g. "i16", "b01-1", "pollux", "acastus"
+  default: |
     {{ ioc_group }}
   validator: >-
-    {% if not (argocd_project | regex_search('^[a-z][a-z-0-9]+$')) %}
-    {{argocd_project}} must be lower case alphanumeric and start with a letter,
+    {% if not (cluster_name | regex_search('^[a-z][a-z-0-9]+$')) %}
+    {{cluster_name}} must be lower case alphanumeric and start with a letter,
     it may contain hyphens
     {% endif %}
 
-cluster_namespace_apps:
+cluster_namespace:
   type: str
-  help: Kubernetes cluster namespace for the Argocd Apps
-  placeholder: e.g. "bl01t-beamline", "j20-beamline", "p47-beamline"
-  validator: >-
-    {% if not (cluster_namespace_apps | regex_search('^[a-z][a-z-0-9]+$')) %}
-    {{cluster_namespace_apps}} must be lower case alphanumeric and start with a letter,
-    it may contain hyphens
-    {% endif %}
+  help: |
+    Kubernetes namespace in which the IOCs and services will run.
 
-cluster_name_apps:
-  type: str
-  help: Name of the k8s cluster for the Argocd Apps
-  placeholder: e.g. "argus", "i20-1", "pollux"
-  default:  >-
-    {{ cluster_namespace_apps }}
+       At DLS this should be "{beamline shortname}-beamline" or "accelerator".
+  placeholder: e.g. "i16-beamline", "b01-1-beamline", "p47-beamline", "accelerator"
+  default: |-
+    {{ ioc_group }}-beamline
   validator: >-
-    {% if not (cluster_name_apps | regex_search('^[a-z][a-z-0-9]+$')) %}
-    {{cluster_name_apps}} must be lower case alphanumeric and start with a letter,
-    it may contain hyphens
-    {% endif %}
-
-cluster_namespace_services:
-  type: str
-  help: Kubernetes cluster namespace where the IOCs and services in this repository will run
-  placeholder: e.g. "bl01t-beamline", "j20-beamline", "p47-beamline"
-  default:  >-
-    {{ cluster_namespace_apps }}
-  validator: >-
-    {% if not (cluster_namespace_apps | regex_search('^[a-z][a-z-0-9]+$')) %}
-    {{cluster_namespace_apps}} must be lower case alphanumeric and start with a letter,
-    it may contain hyphens
-    {% endif %}
-
-cluster_name_services:
-  type: str
-  help: Name of the k8s cluster where the IOCs and services in this repository will run
-  placeholder: e.g. "argus", "i20-1", "pollux"
-  default:  >-
-    {{ cluster_name_apps }}
-  validator: >-
-    {% if not (cluster_name_services | regex_search('^[a-z][a-z-0-9]+$')) %}
-    {{cluster_name_services}} must be lower case alphanumeric and start with a letter,
+    {% if not (cluster_namespace | regex_search('^[a-z][a-z-0-9]+$')) %}
+    {{cluster_namespace}} must be lower case alphanumeric and start with a letter,
     it may contain hyphens
     {% endif %}
 
 git_platform:
   type: str
-  help: Git platform hosting this repository. For missing platform override git_platform, or add your own in a PR.
+  help: Git platform hosting this repository.
   choices:
     - github.com
     - gitlab.diamond.ac.uk
@@ -137,7 +124,9 @@ deployment_repo:
 
 services_repo:
   type: str
-  help: Remote URI of the services repository.
+  help: |
+    Remote URI of the services repository that defines the IOCs and services,
+       that this repository will track.
   default: >-
     {% if git_platform == 'gitlab.diamond.ac.uk' -%}
     https://{{git_platform}}/controls/containers/{{dls_technical_area}}/{{ioc_group}}-services.git
@@ -147,11 +136,11 @@ services_repo:
 
 services_release:
   type: str
-  help: The initial release of the services repository to track e.g. "2024.1.1"
+  help: The initial release of the services repository to track e.g. "2024.12.1" or "main"
 
 logging_url:
   type: str
-  help: URL for centralized logging. For missing platform override logging_url, or add your own in a PR.
+  help: URL for centralized logging.
   choices:
     Skip: ""
     DLS: https://graylog2.diamond.ac.uk/search?rangetype=relative&fields=message%2Csource&width=1489&highlightMessage=&relative=172800&q=pod_name%3A{service_name}*

--- a/template/.gitignore
+++ b/template/.gitignore
@@ -6,3 +6,4 @@ venv*
 **/Chart.lock
 **/charts
 **/*copy
+*.code-workspace

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -5,6 +5,6 @@ This repository holds the definition of Argocd deployed ec services. Each sub fo
 ## Deployment
 To deploy the Argocd root App:
 ```
-# Login to {{ cluster_name_apps }} cluster
-kubectl apply -n {{ cluster_namespace_apps }} -f apps.yaml
+# Login to {{ argocd_cluster }} cluster
+kubectl apply -n {{ cluster_namespace }} -f apps.yaml
 ```

--- a/template/apps.yaml.jinja
+++ b/template/apps.yaml.jinja
@@ -5,10 +5,10 @@ metadata:
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
-  project: {{ argocd_project }}
+  project: {{ cluster_namespace }}
   destination:
-    name: {{ cluster_name_apps }}
-    namespace: {{ cluster_namespace_apps }}
+    name: {{ argocd_cluster }}
+    namespace: {{ cluster_namespace }}
   source:
     path: apps
     repoURL: {{ deployment_repo }}

--- a/template/apps/values.yaml.jinja
+++ b/template/apps/values.yaml.jinja
@@ -1,17 +1,17 @@
 # yaml-language-server: $schema=https://github.com/epics-containers/ec-helm-charts/releases/download/4.0.0/argocd-apps.schema.json
 
-# This file configures an ArgoCD app of apps that represent a 
-# group of beamline or accelerator IOCs and services. The configuration of the 
+# This file configures an ArgoCD app of apps that represent a
+# group of beamline or accelerator IOCs and services. The configuration of the
 # services are in the separate repo indicated by repoURL.
 
 # This repostory only controls which services and which versions of those
 # services should be running on the cluster. It is recommended that this repo
 # be updated by a CI/CD pipeline or configuration tools only.
 
-project: {{ argocd_project }}
+project: {{ cluster_namespace }}
 destination:
-  name: {{ cluster_name_services }}
-  namespace: {{ cluster_namespace_services }}
+  name: {{ cluster_name }}
+  namespace: {{ cluster_namespace }}
 source:
   repoURL: {{ services_repo }}
   targetRevision: {{ services_release }}
@@ -35,6 +35,8 @@ ec_services:
   #            the path is always services/<service> within that repo
   #     removed: set to true to remove the service from the cluster
   #     enabled: set to false to stop a service
-  {{ ioc_group }}-ea-test-01:
-    enabled: true
-    targetRevision: {{ services_release }}
+
+  # example entry
+  #   {{ ioc_group }}-ea-test-01:
+  #     enabled: true
+  #     targetRevision: {{ services_release }}

--- a/template/environment.sh.jinja
+++ b/template/environment.sh.jinja
@@ -14,12 +14,12 @@ echo "Loading environment for {{ ioc_group }} deployment ..."
 #### SECTION 1. Environment variables ##########################################
 
 export EC_CLI_BACKEND="ARGOCD"
-# the argocd app namespace and root app
-export EC_TARGET={{ cluster_namespace_apps }}/{{ ioc_group }}
+# the argocd project and root app
+export EC_TARGET={{ cluster_namespace }}/{{ ioc_group }}
 # the git repo for this project
 export EC_SERVICES_REPO={{ services_repo }}
 # declare your centralised log server Web UI
-export EC_LOG_URL="{{ logging_url }}"
+export EC_LOG_URL='{{ logging_url }}'
 
 #### SECTION 2. Install ec #####################################################
 


### PR DESCRIPTION
simplify the questions and add more help.

Points to note.
Target namespace, Apps namespace and Argo CD project are all the same string at DLS so I condensed down into a single question. If any external users want to set up ArgoCD we can recommend they use the same approach or generalize this template as necessary.

tested against i04 and p47.

Fixes #9 

example interaction:

<pre>This template will create a new repository which describes the set of IOCs and services that Argo CD will track on a Kubernetes cluster.

<font color="#5F87AF">🎤</font><b> A name for the group of IOC and service instances that this</b>
<b>   repository will track.</b>

<b>   At DLS this should be the short beamline name or the technical area</b>
<b>   for accelerator repos.</b>
<b>   </b><font color="#FFAF00"><b>i04</b></font>
<font color="#5F87AF">🎤</font><b> A One line description of the module</b>
<b>   </b><font color="#FFAF00"><b>i04 IOC Instances and Services Deployment Repository for Argo CD</b></font>
<font color="#5F87AF">🎤</font><b> Argocd server DNS Name.</b>

<b>   At DLS this is always &quot;argocd.diamond.ac.uk&quot;</b>
<b>   </b><font color="#FFAF00"><b>argocd.diamond.ac.uk</b></font>
<font color="#5F87AF">🎤</font><b> Cluster in which Argo CD Apps are deployed.</b>

<b>   At DLS this is always &quot;argus&quot;</b>
<b>   </b><font color="#FFAF00"><b>argus</b></font>
<font color="#5F87AF">🎤</font><b> The Kubernetes cluster where the IOCs and services will run.</b>

<b>   At DLS this should be &quot;{beamline shortname}&quot;, &quot;acastus&quot; for the</b>
<b>   accelerator or &quot;pollux&quot; for test beamlines.</b>
<b>   </b><font color="#FFAF00"><b>i04</b></font>
<font color="#5F87AF">🎤</font><b> Kubernetes namespace in which the IOCs and services will run.</b>

<b>   At DLS this should be &quot;{beamline shortname}-beamline&quot; or &quot;accelerator&quot;.</b>
<b>   </b><font color="#FFAF00"><b>i04-beamline</b></font>
<font color="#5F87AF">🎤</font><b> Git platform hosting this repository.</b>
<b>   </b><font color="#FFAF00"><b>gitlab.diamond.ac.uk</b></font>
<font color="#5F87AF">🎤</font><b> The DLS technical area</b>
<b>   </b><font color="#FFAF00"><b>beamline</b></font>
<font color="#5F87AF">🎤</font><b> Remote URI of this repository.</b>
<b>   </b><font color="#FFAF00"><b>https://gitlab.diamond.ac.uk/controls/containers/beamline/i04-deployment.git</b></font>
<font color="#5F87AF">🎤</font><b> Remote URI of the services repository that defines the IOCs and services,</b>
<b>   that this repository will track.</b>
<b>   </b><font color="#FFAF00"><b>https://gitlab.diamond.ac.uk/controls/containers/beamline/i04-services.git</b></font>
<font color="#5F87AF">🎤</font><b> The initial release of the services repository to track e.g. &quot;2024.12.1&quot; or &quot;main&quot;</b>
<b>   </b><font color="#FFAF00"><b>main</b></font>
<font color="#5F87AF">🎤</font><b> URL for centralized logging.</b>
<b>   </b><font color="#FFAF00"><b>DLS</b></font>

</pre>