### PR TITLE
Fix broken gitlab updates

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -104,8 +104,8 @@ dls_technical_area:
   when: >-
     {{ git_platform == 'gitlab.diamond.ac.uk' }}
   validator: >-
-    {% if not (github_org | regex_search('^[a-zA-Z][a-zA-Z-0-9]+$')) %}
-    {{github_org}} must be lower case AlphaNumeric and start with a letter,
+    {% if not (dls_technical_area | regex_search('^[a-zA-Z][a-zA-Z-0-9]+$')) %}
+    {{dls_technical_area}} must be lower case AlphaNumeric and start with a letter,
     it may contain hyphens
     {% endif -%}
   choices:


### PR DESCRIPTION
This fixes a cryptic error that is raised when gitlab repos attempt a `copier update`:
```
[esq51579@pc0146 MY_REPO_NAME]$ copier update .
Updating to template version 4.2.0
Traceback (most recent call last):
  File "/home/esq51579/.local/bin/copier", line 8, in <module>
    sys.exit(copier_app_run())
             ^^^^^^^^^^^^^^^^
  File "/home/esq51579/.local/lib/python3.11/site-packages/plumbum/cli/application.py", line 638, in run
    inst, retcode = subapp.run(argv, exit=False)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/esq51579/.local/lib/python3.11/site-packages/plumbum/cli/application.py", line 633, in run
    retcode = inst.main(*tailargs)
              ^^^^^^^^^^^^^^^^^^^^
  File "/home/esq51579/.local/lib/python3.11/site-packages/copier/cli.py", line 425, in main
    return _handle_exceptions(inner)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/esq51579/.local/lib/python3.11/site-packages/copier/cli.py", line 70, in _handle_exceptions
    method()
  File "/home/esq51579/.local/lib/python3.11/site-packages/copier/cli.py", line 415, in inner
    with self._worker(
  File "/home/esq51579/.local/lib/python3.11/site-packages/copier/main.py", line 237, in __exit__
    raise value
  File "/home/esq51579/.local/lib/python3.11/site-packages/copier/cli.py", line 423, in inner
    worker.run_update()
  File "/home/esq51579/.local/lib/python3.11/site-packages/copier/main.py", line 914, in run_update
    self._apply_update()
  File "/home/esq51579/.local/lib/python3.11/site-packages/copier/main.py", line 935, in _apply_update
    with replace(
  File "/home/esq51579/.local/lib/python3.11/site-packages/copier/main.py", line 237, in __exit__
    raise value
  File "/home/esq51579/.local/lib/python3.11/site-packages/copier/main.py", line 944, in _apply_update
    old_worker.run_copy()
  File "/home/esq51579/.local/lib/python3.11/site-packages/copier/main.py", line 833, in run_copy
    self._ask()
  File "/home/esq51579/.local/lib/python3.11/site-packages/copier/main.py", line 497, in _ask
    raise ValueError(f"Validation error for question '{var_name}': {err_msg}")
ValueError: Validation error for question 'dls_technical_area': expected string or bytes-like object, got 'Undefined'
```
I test this locally with the 4.2.1b1 release using `copier copy gh:epics-containers/deployment-template-argocd MY_REPO_NAME_2 -r 4.2.1b1` and then `copier update . -r 4.2.1b1`


Why the validator passes at `copier copy` time seems like a bug?