### PR TITLE
fix: Update expected tags for gitlab runners

### DIFF
--- a/template/{% if  git_platform == 'gitlab.diamond.ac.uk' %}.gitlab-ci.yml{% endif %}
+++ b/template/{% if  git_platform == 'gitlab.diamond.ac.uk' %}.gitlab-ci.yml{% endif %}
@@ -4,7 +4,8 @@ stages:
 verify:
   stage: verify
   tags:
-    - controls,k8s
+    - epics-containers
+    - argus
   image: bitnami/kubectl:latest
   script:
     - bash ./.gitlab/ci_verify.sh


### PR DESCRIPTION
Prevents gitlab runners from timing out by giving them the same tags as the runners used by the services repositories that live in the same repositories.