### PR TITLE
Move off of bitnami

### DIFF
--- a/template/{% if  git_platform == 'gitlab.diamond.ac.uk' %}.gitlab-ci.yml{% endif %}
+++ b/template/{% if  git_platform == 'gitlab.diamond.ac.uk' %}.gitlab-ci.yml{% endif %}
@@ -6,6 +6,6 @@ verify:
   tags:
     - epics-containers
     - argus
-  image: bitnami/kubectl:latest
+  image: alpine/k8s:1.34.0
   script:
     - bash ./.gitlab/ci_verify.sh


### PR DESCRIPTION
Move off of bitnami image for gitlab CI, use `alpine/k8s` instead. This image is recommended by the Diamond Cloud Team. We have tested it internally on a beamline (b01-1).

Note that alpine/k8s has no `latest` tag so we will need to keep it up to date in this template.