### PR TITLE
update to ec-helm-charts 5.3.0

### DIFF
--- a/template/apps/Chart.yaml
+++ b/template/apps/Chart.yaml
@@ -24,5 +24,5 @@ appVersion: "1.0"
 
 dependencies:
   - name: argocd-apps
-    version: 5.0.1
+    version: 5.3.0
     repository: "oci://ghcr.io/epics-containers/charts"

--- a/template/apps/values.yaml.jinja
+++ b/template/apps/values.yaml.jinja
@@ -4,7 +4,7 @@
 # group of beamline or accelerator IOCs and services. The configuration of the
 # services are in the separate repo indicated by repoURL.
 
-# This repostory only controls which services and which versions of those
+# This repository only controls which services and which versions of those
 # services should be running on the cluster. It is recommended that this repo
 # be updated by a CI/CD pipeline or configuration tools only.
 
@@ -23,7 +23,13 @@ services:
   #     repoURL: optional override for git repo to source the helm chart from
   #            the path is always services/<service> within that repo
   #     removed: set to true to remove the service from the cluster
+  #     removed: set to true to remove the service from the cluster
+  #     ---- fields for ioc-instance (and other future cooperating charts)
   #     enabled: set to false to stop a service
+  #     labels: custom labels to apply to the service resources
+  #     values: TBA - custom values to pass to the helm chart when deploying the service
+  #     ----
+
   {{domain}}-epics-pvcs:
   {{domain}}-epics-opis:{% if gateway %}
   {{domain}}-epics-gateways:{% endif %}


### PR DESCRIPTION
This is pulling in Ollie's changes to helm charts 5.3.0 to add a labels field to services entries.

However its not working. Review with @OCopping next week.